### PR TITLE
have nginx redirect if assembly == hg19

### DIFF
--- a/website/ui/nginx.conf
+++ b/website/ui/nginx.conf
@@ -4,8 +4,10 @@ events {
 http {
     # default set of files and their content types
     include      mime.types;
+    
     # prompt user for download for any undeclared file format
     default_type application/octet-stream;
+    
     # optimization when serving static files
     sendfile     on;
 
@@ -24,6 +26,10 @@ http {
         location ~ ^/hubs/integrative/(.*)$ {
 	    return 301 https://api.wenglab.org/screen_v13/hubs/integrative20/$1;
         }
+
+	if ($arg_assembly = hg19) {
+	   rewrite ^/(.*)$ https://screen-v10.wenglab.org/$1 redirect;
+	}
 
         location / {
             root    /usr/share/nginx/html;


### PR DESCRIPTION
; this is to prevent spewing of errors in api backend, since hg19 not a legal assembly....